### PR TITLE
Hydrus multi model that can spawn hydrus with any number of links

### DIFF
--- a/robots/hydrus/config/multi/NavigationConfig.yaml
+++ b/robots/hydrus/config/multi/NavigationConfig.yaml
@@ -1,0 +1,30 @@
+# Teleop Basic Param
+
+navigation:
+  xy_control_mode: 0
+  # World Pos Control Mode: 0
+  # World Vel Control Mode: 2
+  # Local Vel Control Mode: 3
+  # Attitude Control Mode: 4
+
+
+  takeoff_height: 0.6
+  outdoor_takeoff_height: 1.5
+
+  # teleop operation
+  max_target_vel: 0.5
+  joy_target_vel_interval: 0.005  # 0.2 / 20 = 0.01, 0.005 ~ 0.01  m/s
+  joy_target_z_interval: 0.02
+  max_target_yaw_rate: 0.1 #  0.05
+  teleop_local_frame: fc
+
+  cmd_vel_lev2_gain : 2.0
+  nav_vel_limit : 1.0
+
+  gain_tunning_mode: 0
+  max_target_tilt_angle: 0.2
+  cmd_angle_lev2_gain : 1.5
+
+  # gps waypoint
+  gps_waypoint_threshold: 3.0
+  gps_waypoint_check_du: 1.0

--- a/robots/hydrus/config/multi/RvizInit.yaml
+++ b/robots/hydrus/config/multi/RvizInit.yaml
@@ -1,0 +1,6 @@
+# zeros:
+#   joint1: 1.04
+#   joint2: 1.04
+#   joint3: 1.04
+#   joint4: 1.04
+#   joint5: 1.04

--- a/robots/hydrus/config/multi/Simulation.yaml
+++ b/robots/hydrus/config/multi/Simulation.yaml
@@ -1,0 +1,28 @@
+# overwrite parameter for simulation
+
+sensor_plugin:
+  mocap:
+    ground_truth_sub_name: ground_truth
+  gps:
+    estimate_mode: 4 #1 << 2
+    ned_flag: true # hector_gazebo_plugins/GPS
+
+# ground truth parameter
+# global namespace
+simulation:
+  # gaussian noise
+  ground_truth_pos_noise: 0.001
+  ground_truth_vel_noise: 0.005
+  ground_truth_rot_noise: 0.001
+  ground_truth_angular_noise: 0.005
+
+  # drift model: e^(-dt * drift_frequency) * curr_drift + dt * gaussian_kernel(sqrt( 2 * drift_frequency) * drfit))
+  # drift diviation:
+  ground_truth_vel_drift: 0
+  ground_truth_rot_drift: 0
+  ground_truth_angular_drift: 0
+
+  # drift frequency:
+  ground_truth_vel_drift_frequency: 0
+  ground_truth_rot_drift_frequency: 0
+  ground_truth_angular_drift_frequency: 0

--- a/robots/hydrus/config/multi/multi_vibration_202007/Battery.yaml
+++ b/robots/hydrus/config/multi/multi_vibration_202007/Battery.yaml
@@ -1,0 +1,5 @@
+bat_info:
+        bat_cell: 6
+        bat_resistance: 0.08 # [m Ohm]
+        hovering_current: 10 #[A], MN3510, prop14inch, 3 ~ 4.5
+        low_voltage_thre: 1 #[100%]

--- a/robots/hydrus/config/multi/multi_vibration_202007/FlightControl.yaml
+++ b/robots/hydrus/config/multi/multi_vibration_202007/FlightControl.yaml
@@ -1,0 +1,58 @@
+aerial_robot_control_name: aerial_robot_control/hydrus_tilted_lqi_controller
+
+controller:
+  xy:
+    p_gain: 2.3
+    i_gain: 0.02
+    d_gain: 4.0
+    limit_sum: 3
+    limit_p: 3
+    limit_i: 1.5
+    limit_d: 3
+
+  z:
+    p_gain: 3.6
+    i_gain: 1.55
+    d_gain: 3.4
+    limit_err_p: 1.0
+    limit_sum: 16.5 # N for clamping thrust force
+    limit_p: 10 # m / s^2
+    limit_i: 15 # m / s^2
+    limit_d: 10 # m / s^2
+    landing_err_z: -0.55
+
+  yaw:
+    limit_sum: 6.0 # N for clamping thrust force
+    limit_p: 4.0
+    limit_i: 4.0
+    limit_d: 4.0
+    limit_err_p: 0.4
+    need_d_control: false
+
+  # LQI gain generator
+  lqi:
+    debug: false
+    gain_generate_rate: 15.0
+    init_wait_time: 1
+    gyro_moment_compensation: false
+    clamp_gain: true
+
+    roll_pitch_p: 1100
+    roll_pitch_d: 80
+    roll_pitch_i: 10
+
+    yaw_p: 10.0
+    yaw_i: 0.5
+    yaw_d: 0.50
+
+    q_z: 10.0 # direct feedback gain, old: 10.0
+    q_z_d: 20.0  # direct feedback gain, old: 20.0
+    q_z_i: 10.0  # direct feedback gain, old: 10.0
+
+    r1: 1.0
+    r2: 1.0
+    r3: 1.0
+    r4: 1.0
+
+    trans_constraint_weight: 100
+    att_control_weight: 1

--- a/robots/hydrus/config/multi/multi_vibration_202007/MotorInfo.yaml
+++ b/robots/hydrus/config/multi/multi_vibration_202007/MotorInfo.yaml
@@ -1,0 +1,32 @@
+motor_info:
+        min_pwm: 0.59 # 1180 [ms]
+        max_pwm: 0.9375 # 1875 [ms]
+        min_thrust: 1.0 #  [N]
+        force_landing_thrust: 6.5 #[N]
+        m_f_rate: -0.0172
+        pwm_conversion_mode: 0 # SQRT Mode
+        vel_ref_num: 4
+        ref1:
+                voltage: 25.2
+                max_thrust: 20 # N 
+                polynominal2: 0.07983707 # x10
+                polynominal1: -6.627443098 # x10
+                polynominal0: 12.3593793002 # x1
+        ref2:
+                voltage: 24.2
+                max_thrust: 19 # N 
+                polynominal2: 0.078085358 # x10
+                polynominal1: -6.641338225 # x10
+                polynominal0: 12.9797798522 # x1
+        ref3:
+                voltage: 23.2
+                max_thrust: 18 # N 
+                polynominal2: 0.074527175 # x10
+                polynominal1: -6.440853637 # x10
+                polynominal0: 12.9565178437 # x1
+        ref4:
+                voltage: 22.2
+                max_thrust: 16.8 # N 
+                polynominal2: 0.071758366 # x10
+                polynominal1: -6.346135548 # x10
+                polynominal0: 13.2669467083 # x1

--- a/robots/hydrus/config/multi/multi_vibration_202007/RobotModel.yaml
+++ b/robots/hydrus/config/multi/multi_vibration_202007/RobotModel.yaml
@@ -1,0 +1,8 @@
+# robot model plugin
+robot_model_plugin_name: hydrus_tilted_robot_model
+
+# feasible control configuration
+fc_t_min_thre: 0.01
+fc_rp_min_thre: 1.8
+rp_position_margin_thre: 0.13 # deprecated
+

--- a/robots/hydrus/config/multi/multi_vibration_202007/ServoCommon.yaml
+++ b/robots/hydrus/config/multi/multi_vibration_202007/ServoCommon.yaml
@@ -1,0 +1,15 @@
+servo_controller:
+  joints:
+    state_sub_topic: servo/states
+    ctrl_pub_topic: servo/target_states
+    torque_pub_topic: servo/torque_enable
+    angle_sgn: 1
+    angle_scale: 0.00076699
+    zero_point_offset: 2047
+    torque_scale: 0.03483 # convert to N*m
+
+    # for simulation
+    simulation:
+      pid: {p: 50.0, i: 0.01, d: 2.0}
+      type: effort_controllers/JointPositionController
+

--- a/robots/hydrus/config/multi/multi_vibration_202007/StateEstimation.yaml
+++ b/robots/hydrus/config/multi/multi_vibration_202007/StateEstimation.yaml
@@ -1,0 +1,53 @@
+# Sensor Fuser Loader
+estimation:
+        # sensor plugin
+        sensor_list:
+        - sensor_plugin/imu
+        - sensor_plugin/mocap
+        - sensor_plugin/alt
+        - sensor_plugin/gps
+
+        # egomotion estimation
+        egomotion_list:
+        - kalman_filter/kf_pos_vel_acc
+        - kalman_filter/kf_pos_vel_acc
+        - kalman_filter/kf_pos_vel_acc
+
+        # experiment estimation
+        experiment_list:
+        - kalman_filter/kf_pos_vel_acc
+        - kalman_filter/kf_pos_vel_acc
+        - kalman_filter/kf_pos_vel_acc
+
+        # specific id(int) of sensor fuser, axis for kf
+        fuser_egomotion_id1: 8 # 1 << 3
+        fuser_egomotion_id2: 16 # 1 << 4
+        fuser_egomotion_id3: 32 # 1 << 5
+
+        fuser_experiment_id1: 8 # 1 << 3
+        fuser_experiment_id2: 16 # 1 << 4
+        fuser_experiment_id3: 32 # 1 << 5
+
+        # specific name of sensor fuser
+        fuser_egomotion_name1: /ee/x
+        fuser_egomotion_name2: /ee/y
+        fuser_egomotion_name3: /ee/z
+
+        fuser_experiment_name1: /ex/x
+        fuser_experiment_name2: /ex/y
+        fuser_experiment_name3: /ex/z
+
+
+# EGOMOTION_ESTIMATION_MODE = 0
+# EXPERIMENT_MODE = 1
+# GROUND_TRUTH_MODE = 2
+
+sensor_plugin:
+        imu:
+                estimate_mode: 3 # 1<<0 + 1<<1
+        mocap:
+                estimate_mode: 6 # 1<<1 + 1<<2
+        alt:
+                estimate_mode: 1 # 1<<0
+        gps:
+                estimate_mode: 1 # 1<<0

--- a/robots/hydrus/config/multi/multi_vibration_202007/TorsionEstimatorConfig.yaml
+++ b/robots/hydrus/config/multi/multi_vibration_202007/TorsionEstimatorConfig.yaml
@@ -1,0 +1,6 @@
+kf_step_rate: 30.0
+
+torsion_vel_cutoff_freq: 3.0
+torsion_vel_q: 1.0
+torsion_cutoff_freq: 3.0
+torsion_q: 1.0

--- a/robots/hydrus/launch/bringup.launch
+++ b/robots/hydrus/launch/bringup.launch
@@ -19,6 +19,12 @@
   <arg name="robot_id" default="" />
   <arg name="robot_ns" value="hydrus$(arg robot_id)" />
   <arg name="config_dir" default="$(find hydrus)/config/$(arg type)" />
+  <arg name="links" default="4" if="$(eval arg('type')=='multi')"/>
+
+  <arg name="description_mode" value="urdf" unless="$(arg simulation)" />
+  <arg name="description_mode" value="gazebo" if="$(arg simulation)" />
+  <arg name="robot_model" value="$(find hydrus)/robots/$(arg type)/$(arg onboards_model)/robot.$(arg description_mode).xacro" unless="$(arg direct_model)"/>
+  <arg name="robot_model" value="$(arg direct_model_name)" if="$(arg direct_model)"/>
 
   ###########  Parameters  ###########
   <group ns="$(arg robot_ns)">
@@ -38,7 +44,14 @@
     <rosparam file="$(arg config_dir)/$(arg onboards_model)/MotorInfo.yaml" command="load" />
 
     ###########  Servo Config  ###########
-    <rosparam file="$(arg config_dir)/$(arg onboards_model)/Servo.yaml" command="load" />
+    <rosparam file="$(arg config_dir)/$(arg onboards_model)/Servo.yaml" command="load" unless="$(eval arg('type')=='multi')"/>
+    <group if="$(eval arg('type')=='multi')">
+      <rosparam file="$(arg config_dir)/$(arg onboards_model)/ServoCommon.yaml" command="load"/>
+      <include file="$(find hydrus)/launch/includes/$(arg onboards_model)/recursive_config.launch" >
+        <arg name="nr" value="$(eval arg('links')-1)"/>
+        <arg name="links" value="$(arg links)"/>
+      </include>
+    </group>
 
     ###########  Battery Config  ###########
     <rosparam file="$(arg config_dir)/$(arg onboards_model)/Battery.yaml" command="load" />
@@ -55,23 +68,21 @@
   </group>
 
   ###########  Base Platform  ###########
-  <node pkg="aerial_robot_base" type="aerial_robot_base_node" name="aerial_robot_base_node" ns="$(arg robot_ns)" output="screen" >
+  <node pkg="aerial_robot_base" type="aerial_robot_base_node" name="aerial_robot_base_node" ns="$(arg robot_ns)" output="screen">
     <param name="tf_prefix" value="$(arg robot_ns)"/>
     <param name="param_verbose" value="false"/>
     <param name="main_rate" value="40"/>
   </node>
 
   ###########  Robot Model  ###########
-  <arg name="description_mode" value="urdf" unless="$(arg simulation)" />
-  <arg name="description_mode" value="gazebo" if="$(arg simulation)" />
   <include file="$(find aerial_robot_model)/launch/aerial_robot_model.launch" >
     <arg name="headless" value="$(arg headless)" />
-    <arg name="robot_model" value="$(find hydrus)/robots/$(arg type)/$(arg onboards_model)/robot.$(arg description_mode).xacro" unless="$(arg direct_model)"/>
-    <arg name="robot_model" value="$(arg direct_model_name)" if="$(arg direct_model)"/>
+    <arg name="robot_model" value="$(arg robot_model)" />
     <arg name="robot_ns" value="$(arg robot_ns)" />
     <arg name="rviz_config" value="$(find hydrus)/config/rviz_config" />
     <arg name="rviz_init_pose" value="$(arg config_dir)/RvizInit.yaml" />
     <arg name="need_joint_state" value="false" if ="$(eval arg('simulation') + arg('real_machine') > 0)"/>
+    <arg name="model_options" value="links:=$(arg links)" if="$(eval arg('type')=='multi')"/>
   </include>
 
   ###########  Sensors ###########
@@ -79,7 +90,9 @@
     <arg name="real_machine" value="$(arg real_machine)" />
     <arg name="simulation" value="$(arg simulation)" />
     <arg name="robot_ns" value="$(arg robot_ns)" />
-  </include >
+    <arg name="links" value="$(arg links)" if="$(eval arg('type')=='multi')"/>
+    <arg name="robot_model" value="$(arg robot_model)" if="$(eval arg('type')=='multi')"/>
+  </include>
 
   ###########  Servo Bridge  ###########
   <node pkg="aerial_robot_model" type="servo_bridge_node" name="servo_bridge" ns="$(arg robot_ns)" output="screen" />

--- a/robots/hydrus/launch/includes/multi_vibration_202007/mocap.launch
+++ b/robots/hydrus/launch/includes/multi_vibration_202007/mocap.launch
@@ -1,0 +1,46 @@
+<launch>
+  <node pkg="mocap_optitrack"
+    type="mocap_node"
+    name="link_mocap_node"
+    respawn="false"
+    launch-prefix=""
+    required="true">
+    <rosparam>
+      rigid_bodies:
+         '1':
+               pose: mocap/link3/pose
+               pose2d: mocap/link3/ground_pose
+               child_frame_id: link3
+               parent_frame_id: world
+         '2':
+               pose: mocap/link1/pose
+               pose2d: mocap/link1/ground_pose
+               child_frame_id: link1
+               parent_frame_id: world
+         '3':
+               pose: mocap/link2/pose
+               pose2d: mocap/link2/ground_pose
+               child_frame_id: link2
+               parent_frame_id: world
+         '4':
+               pose: mocap/link4/pose
+               pose2d: mocap/link4/ground_pose
+               child_frame_id: link4
+               parent_frame_id: world
+         '5':
+               pose: mocap/link5/pose
+               pose2d: mocap/link5/ground_pose
+               child_frame_id: link5
+               parent_frame_id: world
+         '6':
+               pose: mocap/link6/pose
+               pose2d: mocap/link6/ground_pose
+               child_frame_id: link6
+               parent_frame_id: world
+      optitrack_config:
+         multicast_address:
+               239.255.42.99
+    </rosparam>
+  </node>
+
+</launch>

--- a/robots/hydrus/launch/includes/multi_vibration_202007/recursive_config.launch
+++ b/robots/hydrus/launch/includes/multi_vibration_202007/recursive_config.launch
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<launch>
+   <arg name="nr" default="1"/> 
+   <arg name="links" default="1"/> 
+
+  <!-- Servo controllers-->
+  <group ns="servo_controller/joints/controller$(arg nr)">
+    <param name="id" value="$(eval arg('nr')-1)"/>
+    <param name="name" value="joint$(arg nr)"/>
+    <param name="simulation/init_value" value="$(eval 3.13*2/arg('links'))"/>
+  </group>
+
+   <!-- recursively start new node -->
+   <include file="$(dirname)/recursive_config.launch" if="$(eval arg('nr') - 1 > 0)">
+     <arg name="nr" value="$(eval arg('nr') - 1)"/>
+     <arg name="links" value="$(arg links)"/>
+   </include>
+
+</launch>

--- a/robots/hydrus/launch/includes/multi_vibration_202007/sensors.launch.xml
+++ b/robots/hydrus/launch/includes/multi_vibration_202007/sensors.launch.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0"?>
+<launch>
+
+  <arg name="real_machine" default="false" />
+  <arg name="simulation" default="false" />
+  <arg name="robot_ns" default="hydrus" />
+  <arg name="links" default="6" />
+  <arg name="robot_model" />
+  <arg name="mocap_for_torsion" default="true" />
+
+  <group ns="$(arg robot_ns)">
+
+    <group if="$(arg real_machine)">
+      <group unless="$(arg simulation)">
+        <!-- fc & IMU & GPS -->
+        <include file="$(find spinal_ros_bridge)/launch/serial.launch" >
+          <arg name="baud" value="921600" />
+          <arg name="port" value="/dev/flight_controller" />
+        </include>
+
+        <!-- mocap -->
+        <include file="$(find aerial_robot_base)/launch/external_module/mocap.launch" />
+
+        <group if="$(arg mocap_for_torsion)">
+          <include file="$(find hydrus)/launch/includes/multi_vibration_202007/mocap.launch" />
+        </group>
+
+        <!-- leddar one -->
+        <include file="$(find leddar_one)/launch/leddar_one.launch" >
+          <arg name="port" value="/dev/leddarone" />
+        </include>
+
+      </group>
+    </group>
+
+    <!-- basic configuration for sensors (e.g. noise sigma) -->
+    <rosparam file="$(find hydrus)/config/sensors/imu/spinal.yaml" command="load" />
+    <rosparam file="$(find aerial_robot_base)/config/sensors/gps/ublox_m8n.yaml" command="load" />
+    <rosparam file="$(find aerial_robot_base)/config/sensors/mocap.yaml" command="load" />
+    <rosparam file="$(find aerial_robot_base)/config/sensors/altmeter/leddar_one.yaml" command="load" />
+
+  </group>
+
+</launch>

--- a/robots/hydrus/robots/multi/multi_vibration_202007/robot.gazebo.xacro
+++ b/robots/hydrus/robots/multi/multi_vibration_202007/robot.gazebo.xacro
@@ -1,0 +1,97 @@
+<?xml version="1.0"?>
+<robot
+    xmlns:xacro="http://www.ros.org/wiki/xacro" name="hydrus" >
+
+  <xacro:arg name="robot_name" default="hydrus" />
+
+  <xacro:arg name="sim" default="false"/>
+
+  <xacro:arg name="links" default="8"/>
+  <xacro:arg name="fix_rotor" default="0"/>
+
+  <!-- robot urdf -->
+  <xacro:include filename="$(find hydrus)/robots/multi/multi_vibration_202007/robot.urdf.xacro" />
+
+  <!-- gazebo plugin for default controller and sensors -->
+  <xacro:include filename="$(find aerial_robot_simulation)/xacro/spinal.gazebo.xacro" />
+  <xacro:gazebo_spinal robot_name="$(arg robot_name)" />
+
+  <xacro:if value="$(arg sim)">
+    <!-- joint torsional spring plugin -->
+    <gazebo>
+    <xacro:macro name="loop_plugin_torsion" params="links_qty">
+      <plugin name="torsion${links_qty-1}_torsional_spring" filename="libjoint_torsional_spring_plugin.so">
+        <kx>60</kx>
+        <set_point>0</set_point>
+        <joint>torsion${links_qty-1}</joint>
+      </plugin>
+
+      <xacro:if value="${links_qty-2}">
+        <xacro:loop_plugin_torsion links_qty="${links_qty-1}" />
+      </xacro:if>
+    </xacro:macro>
+    <xacro:loop_plugin_torsion links_qty="$(arg links)" />
+    </gazebo>
+
+    <gazebo>
+      <plugin name="torsion_joint_state_publisher" filename="libgazebo_ros_joint_state_publisher.so">
+        <!-- <robotNamespace>/$(arg robot_name)/link_torsion_groundtruth</robotNamespace> -->
+        <robotNamespace>/$(arg robot_name)/link_torsion</robotNamespace>
+        <!-- <jointName>torsion1, torsion2, torsion3, torsion4, torsion5</jointName> -->
+        <jointName>torsion1, torsion2, torsion3, torsion4, torsion5, torsion6, torsion7</jointName>
+        <updateRate>50.0</updateRate>
+        <alwaysOn>true</alwaysOn>
+      </plugin>
+    </gazebo>
+  </xacro:if>
+
+  <!-- neuron imu plugin -->
+  <xacro:macro name="loop_plugin_neuron_imu" params="links_qty">
+    <gazebo reference="neuron${links_qty}_imu">
+      <gravity>true</gravity>
+      <sensor name="neuron${links_qty}_imu" type="imu">
+        <always_on>true</always_on>
+        <update_rate>50</update_rate>
+        <visualize>true</visualize>
+        <topic>__default_topic__</topic>
+        <plugin filename="libgazebo_ros_imu_sensor.so" name="imu_plugin">
+          <topicName>/$(arg robot_name)/neuron${links_qty}_imu</topicName>
+          <bodyName>neuron${links_qty}_imu</bodyName>
+          <updateRateHZ>50.0</updateRateHZ>
+          <gaussianNoise>0.001</gaussianNoise>
+          <xyzOffset>0 0 0</xyzOffset>
+          <rpyOffset>0 0 0</rpyOffset>
+          <frameName>neuron${links_qty}_imu</frameName>
+        </plugin>
+        <pose>0 0 0 0 0 0</pose>
+      </sensor>
+    </gazebo>
+    <xacro:if value="${links_qty-1}">
+        <xacro:loop_plugin_neuron_imu links_qty="${links_qty-1}" />
+    </xacro:if>
+  </xacro:macro>
+
+  <xacro:loop_plugin_neuron_imu links_qty="$(arg links)" />
+  <!-- end of neuron imu plugin -->
+
+  <!-- publish real position of neurons -->
+  <xacro:macro name="loop_plugin_neuron_groundtruth" params="links_qty">
+    <gazebo>
+      <plugin filename="libgazebo_ros_p3d.so" name="neuron1_groundtruth">
+        <bodyName>thrust${links_qty}</bodyName>
+        <topicName>/$(arg robot_name)/neuron${links_qty}_groundtruth</topicName>
+        <updateRate>20</updateRate>
+        <gaussianNoise>0.005</gaussianNoise>
+        <xyzOffset>0 0 0</xyzOffset>
+        <rpyOffset>0 0 0</rpyOffset>
+        <frameName>world</frameName>
+      </plugin>
+    </gazebo>
+
+    <xacro:if value="${links_qty-1}">
+        <xacro:loop_plugin_neuron_groundtruth links_qty="${links_qty-1}" />
+    </xacro:if>
+  </xacro:macro>
+  <xacro:loop_plugin_neuron_groundtruth links_qty="$(arg links)" />
+  <!-- end of publish real position of neurons -->
+</robot>

--- a/robots/hydrus/robots/multi/multi_vibration_202007/robot.urdf.xacro
+++ b/robots/hydrus/robots/multi/multi_vibration_202007/robot.urdf.xacro
@@ -1,0 +1,139 @@
+<?xml version="1.0"?>
+<robot
+    xmlns:xacro="http://www.ros.org/wiki/xacro" name="hydrus" >
+
+  <xacro:arg name="sim" default="false"/>
+
+  <xacro:arg name="links" default="8"/>
+  <xacro:arg name="fix_rotor" default="0"/>
+  <xacro:arg name="tilt_mode" default="1"/>
+  <xacro:arg name="tilt_angle" default="20"/>
+
+  <!-- basic kinematics model -->
+  <xacro:include filename="$(find hydrus)/urdf/common.xacro" />
+  <xacro:include filename="$(find hydrus)/urdf/link.urdf.xacro" />
+
+  <xacro:if value="$(arg sim)">
+    <xacro:macro name="loop_link_sim" params="links_qty">
+        <xacro:if value="${links_qty==$(arg links)}">
+          <xacro:hydrus_link links="$(arg links)" self="${links_qty}" rotor_direction="${int(pow(-1, links_qty))}" with_battery = "1"  vibrate = "0" tilt_mode="$(arg tilt_mode)" tilt_angle="$(arg tilt_angle)" fix_rotor="$(arg fix_rotor)"/>
+        </xacro:if>
+        <xacro:unless value="${links_qty==$(arg links)}">
+          <xacro:hydrus_link links="$(arg links)" self="${links_qty}" rotor_direction="${int(pow(-1, links_qty))}" with_battery = "1"  vibrate = "1" tilt_mode="$(arg tilt_mode)" tilt_angle="$(arg tilt_angle)" fix_rotor="$(arg fix_rotor)"/>
+        </xacro:unless>
+
+      <xacro:if value="${links_qty-1}">
+        <xacro:loop_link_sim links_qty="${links_qty-1}" />
+      </xacro:if>
+    </xacro:macro>
+
+    <xacro:loop_link_sim links_qty="$(arg links)"/>
+  </xacro:if>
+
+  <xacro:unless value="$(arg sim)">
+    <xacro:macro name="loop_link_real" params="links_qty">
+      <xacro:hydrus_link links="$(arg links)" self="${links_qty}" rotor_direction="${int(pow(-1, links_qty))}" with_battery = "1" tilt_mode="$(arg tilt_mode)" tilt_angle="$(arg tilt_angle)"/>
+
+      <xacro:if value="${links_qty-1}">
+        <xacro:loop_link_real links_qty="${links_qty-1}" />
+      </xacro:if>
+    </xacro:macro>
+
+    <xacro:loop_link_real links_qty="$(arg links)"/>
+  </xacro:unless>
+
+
+  <!-- onboard -->
+  <!-- 1.  processor -->
+  <!-- 1.1 flight controller -->
+  <xacro:extra_module name = "fc" parent = "link${int($(arg links)/2)}" visible = "1"
+                      model_url = "package://hydrus/urdf/mesh/ver2/flight_controller/spinal.dae"> <!-- same with intel euclid -->
+    <origin xyz="${link_length / 2 + 0.2221} ${-4.4*0.001} 0.02135" rpy="0 0 0"/>
+    <inertial>
+      <mass value = "0.05" />
+      <origin xyz="${13*0.001} ${4.4*0.001} ${-9*0.001}" rpy="0 0 0"/>
+      <inertia
+          ixx="0.00001" ixy="0.0" ixz="0.0"
+          iyy="0.00001" iyz="0.0"
+          izz="0.00002"/>
+    </inertial>
+  </xacro:extra_module>
+  <!-- end: flight controller -->
+
+  <!-- 1.2 processor: jetson tx2 -->
+  <!-- confirm the inertial parameter with real machine -->
+  <xacro:extra_module name = "pc" parent = "link${int($(arg links)/2 +1)}" visible = "1"
+                      model_url = "package://hydrus/urdf/mesh/ver2/processor/jetson_tx2_unit.dae" >
+    <origin xyz="${link_length / 2 - 0.23775} 0.0 ${-0.01}" rpy="0 0 0"/>
+    <inertial>
+      <mass value = "0.181" />
+      <origin xyz="${18 * 0.001} ${4 * 0.001} ${-18 * 0.001}" rpy="0 0 0"/>
+      <inertia
+          ixx="0.00007" ixy="0.0" ixz="0.0"
+          iyy="0.00003" iyz="0.0"
+          izz="0.00009"/>
+    </inertial>
+  </xacro:extra_module>
+  <!-- end: processor: jetson tx2 -->
+
+  <!-- 2.  sensor -->
+  <!-- 2.1 leddar one -->
+  <xacro:extra_module name = "leddarone" parent = "link${int($(arg links)/2 +1)}" visible = "1"
+                      model_url = "package://hydrus/urdf/mesh/sensor/leddar_one_tx2_attached_mode.dae">
+    <origin xyz="${link_length/2 - 0.1855} 0.0 -0.0626" rpy="${pi} 0 0"/>
+    <inertial>
+      <origin xyz="-0.008 0.0 0.0" rpy="0 0 0"/>
+      <mass value="0.025"/>
+      <inertia
+          ixx="0.00001" iyy="0.000006" izz="0.00001"
+          ixy="0.000000" ixz="0.000000" iyz="0.000000"/>
+    </inertial>
+  </xacro:extra_module>
+  <!-- end: leddar one -->
+
+  <!-- 2.2 gps -->
+  <xacro:extra_module name = "gps" parent = "link${int($(arg links)/2)}" visible = "1"
+                      model_url = "package://hydrus/urdf/mesh/sensor/gps_ublox_m8n.dae">
+    <origin xyz="${link_length/2 + 0.1925} 0.0 0.152" rpy="0 0 0"/>
+    <inertial>
+      <origin xyz="0.000000 0.000000 -0.013" rpy="0 0 0"/>
+      <mass value="0.042"/>
+      <inertia
+          ixx="0.00006" iyy="0.00006" izz="0.000007"
+          ixy="0.000000" ixz="0.000000" iyz="0.000000"/>
+    </inertial>
+  </xacro:extra_module>
+  <xacro:extra_module name = "magnet" parent = "gps">
+    <origin xyz="0 0 0" rpy="0 0 0"/>
+    <inertial>
+      <mass value = "0.00001" />
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <inertia
+          ixx="0.000001" ixy="0.0" ixz="0.0"
+          iyy="0.000001" iyz="0.0"
+          izz="0.000002"/>
+    </inertial>
+  </xacro:extra_module>
+  <!-- end: gps -->
+
+  <!-- neuron imus -->
+  <xacro:macro name="loop_neuron_imus" params="links_qty">
+    <xacro:extra_module name = "neuron${links_qty}_imu" parent = "link${links_qty}">
+      <!-- <origin xyz="${link_length - 0.03} 0 ${0.02}" rpy="0 0 0"/> -->
+      <origin xyz="${0.03} 0 ${0.02}" rpy="0 0 0"/>
+      <inertial>
+        <mass value = "0.00001" />
+        <origin xyz="0 0 0" rpy="0 0 0"/>
+        <inertia
+          ixx="0.000001" ixy="0.0" ixz="0.0"
+          iyy="0.000001" iyz="0.0"
+          izz="0.000002"/>
+      </inertial>
+    </xacro:extra_module>
+    <xacro:if value="${links_qty-1}">
+      <xacro:loop_neuron_imus links_qty="${links_qty-1}" />
+    </xacro:if>
+  </xacro:macro>
+  <xacro:loop_neuron_imus links_qty="$(arg links)"/>
+  <!-- end: neuron imus -->
+</robot>


### PR DESCRIPTION
I added Hydrus multi model that can spawn hydrus with any number of links.

`roslaunch hydrus bringup.launch real_machine:=false simulation:=true headless:=false type:=multi onboards_model:=multi_vibration_202007 links:=9`

![Screenshot from 2021-03-29 16-53-25](https://user-images.githubusercontent.com/16531208/112804707-ae20e500-90af-11eb-8f7d-d5f2dc27f2d3.png)
