### PR TITLE
[WIP] update the usage of motion capture

### DIFF
--- a/aerial_robot_base/launch/external_module/mocap.launch
+++ b/aerial_robot_base/launch/external_module/mocap.launch
@@ -16,8 +16,9 @@
                child_frame_id: baselink
                parent_frame_id: world
       optitrack_config:
-         multicast_address:
-               239.255.42.99
+         multicast_address: 239.255.42.99
+         command_port: 1510
+         data_port: 1511
     </rosparam>
   </node>
 

--- a/aerial_robot_base/package.xml
+++ b/aerial_robot_base/package.xml
@@ -21,6 +21,7 @@
   <run_depend>aerial_robot_estimation</run_depend>
   <run_depend>aerial_robot_model</run_depend>
   <run_depend>joy</run_depend>
+  <run_depend>mocap_optitrack</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>rospy</run_depend>
   <run_depend>rostest</run_depend>

--- a/aerial_robot_kinetic.rosinstall
+++ b/aerial_robot_kinetic.rosinstall
@@ -16,12 +16,6 @@
     uri: https://github.com/JSKAerialRobot/sensor_interface.git
     version: da9c42f
 
-# motion capture(optitrack)
-- git:
-    local-name: mocap_optitrack
-    uri: https://github.com/tongtybj/mocap_optitrack.git
-    version: fix_multiple_rigid_bodies_parse_bug
-
 # realsense
 - git:
     local-name: realsense-ros

--- a/aerial_robot_melodic.rosinstall
+++ b/aerial_robot_melodic.rosinstall
@@ -16,12 +16,6 @@
     uri: https://github.com/JSKAerialRobot/sensor_interface.git
     version: da9c42f
 
-# motion capture(optitrack)
-- git:
-    local-name: mocap_optitrack
-    uri: https://github.com/tongtybj/mocap_optitrack.git
-    version: fix_multiple_rigid_bodies_parse_bug
-
 # realsense
 #- git:
 #    local-name: realsense-ros


### PR DESCRIPTION
Currently, we update the version of  [Motive](https://www.optitrack.jp/products/software/optitrack/motive.html) from 1.7.3 (2015) to 2.2.0 (2019 final version) to support the latest product [Optitrack PrimeX13/13W](https://www.optitrack.jp/products/camera/primex13.html).

Fortunately, the update of ros package [mocap_optitrack](http://wiki.ros.org/mocap_optitrack) has caught up on the laster Motive version. So we can directly use the this official ros package instead of [the previous patched one](https://github.com/tongtybj/aerial_robot/blob/1.2.0/aerial_robot_kinetic.rosinstall#L13-L17).

I am still testing the official mocap_optitrack with different host PCs and robots, because I found the publish rate from Mocap PC (with Windows) to a Thinkpad PC significantly degrades (i.e., 100Hz -> 10Hz); but the puslibh rate in some onboard PC in hydrus (e.g., Intel NUC) is very stable. 

After the investigation, I will re-announce the shift from old mocap system to this new system.