### PR TITLE
add topic remap in mocap.launch

### DIFF
--- a/aerial_robot_base/launch/external_module/mocap.launch
+++ b/aerial_robot_base/launch/external_module/mocap.launch
@@ -20,6 +20,7 @@
          command_port: 1510
          data_port: 1511
     </rosparam>
+    <remap from="~mocap/pose" to="mocap/pose" />
   </node>
 
 </launch>


### PR DESCRIPTION
The topic name of rigid object pose from optitrack is changed, so this remap is necessary.