### PR TITLE
RTK GPS for sensor fusion

### DIFF
--- a/aerial_robot_base/config/sensors/gps/ublox_m9n.yaml
+++ b/aerial_robot_base/config/sensors/gps/ublox_m9n.yaml
@@ -1,11 +1,11 @@
 sensor_plugin:
         gps: #single GPS
-                min_est_sat_num: 7
+                min_est_sat_num: 10
                 vel_noise_sigma:  0.02 #0.05 -> 0.01 -> 0.02
                 pos_noise_sigma:  1.0
                 gps_ros_sub_name: sim/gps/fix
                 sensor_frame: gps
                 ned_flag: true #north(x)-east(y)-down(z) frame
                 time_sync: true
-                delay: -0.45 # daylight: -0.45, night: -0.5
+                delay: -0.35 # alternative: -0.25 # Ublox M9N normal: -0.25 ~ 0.35, -0.35 is good @2021.05.24 Kashiwa. TODO: auto-calibra with VIO
                 #only_use_vel: true # debug

--- a/aerial_robot_base/config/sensors/gps/ublox_rtk_m8p.yaml
+++ b/aerial_robot_base/config/sensors/gps/ublox_rtk_m8p.yaml
@@ -1,0 +1,16 @@
+# RTK GPS,
+# Note: we need a normal GPS as gps1, otherwise following yaml file would be never loaded
+
+sensor_plugin:
+        gps2: # we need a normal GPS as gps1, otherwise following yaml file would be never loaded
+                rtk: true
+                min_est_sat_num: 10
+                pos_noise_sigma:  1.0
+                gps_ros_sub_name: rtk_gps/fix
+                rtk_pos_sub_name: rtk_gps/rel_pos
+                sensor_frame: rtk_gps
+                ned_flag: true #north(x)-east(y)-down(z) frame
+                time_sync: true
+                delay: -0.25
+                #rtk_offset: false # Please overwrite this parameter in your StateEstimation.yaml. **Not Here!!*. True: set the takeoff point as zero for RTK model, otherwise, the zero point is the base station like mocap. Default is false
+

--- a/aerial_robot_base/launch/external_module/rtk_gps.launch
+++ b/aerial_robot_base/launch/external_module/rtk_gps.launch
@@ -1,0 +1,19 @@
+<launch>
+
+  <!-- Ublox RTK GPS (NEO-M8P or ZED-F9P) -->
+
+  <arg name = "ntrip_ip" default="192.168.1.1" />
+  <arg name = "module_name" default="holybro_m8p" />
+
+  <!-- device interface with ublox gps -->
+  <include file="$(find ublox_gps)/launch/ublox_device.launch" >
+    <arg name="param_file_name" value="$(arg module_name)" />
+    <arg name="node_name" value="rtk_gps" />
+  </include>
+
+  <!-- NTRIP caster (server) IP address -->
+  <include file="$(find ntrip_ros)/launch/ntrip_ros.launch" >
+    <arg name="ip" value="$(arg ntrip_ip)" />
+  </include>
+
+</launch>

--- a/aerial_robot_control/src/flight_navigation.cpp
+++ b/aerial_robot_control/src/flight_navigation.cpp
@@ -728,17 +728,10 @@ void BaseNavigator::update()
           {
             if(ros::Time::now().toSec() - gps_waypoint_time_ > gps_waypoint_check_du_)
               {
-                tf::Vector3 gps_waypoint_delta;
+                auto base_wp = estimator_->getCurrGpsPoint();
+                tf::Matrix3x3 convert_frame; convert_frame.setRPY(M_PI, 0, 0); // NED -> XYZ
+                tf::Vector3 gps_waypoint_delta =  convert_frame * sensor_plugin::Gps::wgs84ToNedLocalFrame(base_wp, target_wp_);
 
-                for (const auto& handler: estimator_->getGpsHandlers())
-                  {
-                    if(handler->getStatus() == Status::ACTIVE)
-                      {
-                        auto base_wp = boost::static_pointer_cast<sensor_plugin::Gps>(handler)->getCurrentPoint();
-                        gps_waypoint_delta = boost::static_pointer_cast<sensor_plugin::Gps>(handler)->getWolrdFrame() * sensor_plugin::Gps::wgs84ToNedLocalFrame(base_wp, target_wp_);
-                        break;
-                      }
-                  }
 
                 if(gps_waypoint_delta.length() < gps_waypoint_threshold_)
                   gps_waypoint_ = false;
@@ -779,17 +772,10 @@ void BaseNavigator::update()
               {
                 if(gps_waypoint_)
                   {
-                    tf::Vector3 gps_waypoint_delta;
+                    auto base_wp = estimator_->getCurrGpsPoint();
+                    tf::Matrix3x3 convert_frame; convert_frame.setRPY(M_PI, 0, 0); // NED -> XYZ
+                    tf::Vector3 gps_waypoint_delta =  convert_frame * sensor_plugin::Gps::wgs84ToNedLocalFrame(base_wp, target_wp_);
 
-                    for (const auto& handler: estimator_->getGpsHandlers())
-                      {
-                        if(handler->getStatus() == Status::ACTIVE)
-                          {
-                            auto base_wp = boost::static_pointer_cast<sensor_plugin::Gps>(handler)->getCurrentPoint();
-                            gps_waypoint_delta = boost::static_pointer_cast<sensor_plugin::Gps>(handler)->getWolrdFrame() * sensor_plugin::Gps::wgs84ToNedLocalFrame(base_wp, target_wp_);
-                            break;
-                          }
-                      }
                     ROS_WARN("back to pos nav control for GPS way point, gps waypoint delta: %f, %f", gps_waypoint_delta.x(), gps_waypoint_delta.y());
                     gps_waypoint_  = false;
                   }

--- a/aerial_robot_estimation/include/aerial_robot_estimation/state_estimation.h
+++ b/aerial_robot_estimation/include/aerial_robot_estimation/state_estimation.h
@@ -43,6 +43,7 @@
 #include <deque>
 #include <fnmatch.h>
 #include <geometry_msgs/TransformStamped.h>
+#include <geographic_msgs/GeoPoint.h>
 #include <iostream>
 #include <kalman_filter/kf_base_plugin.h>
 #include <map>
@@ -306,7 +307,8 @@ namespace aerial_robot_estimation
 
       if(timestamp > timestamp_qu_.back())
         {
-          ROS_WARN_COND(verbose, "estimation: sensor timestamp %f is later than the latest timestamp %f in queue", timestamp, timestamp_qu_.back());
+          ROS_WARN_COND(verbose, "estimation: sensor timestamp %f is later than the latest timestamp %f in queue",
+                        timestamp, timestamp_qu_.back());
 
           return false;
         }
@@ -396,6 +398,10 @@ namespace aerial_robot_estimation
     /* att control mode is for user to manually control x and y motion by attitude control */
     inline void setForceAttControlFlag (bool flag) {force_att_control_flag_ = flag; }
     inline bool getForceAttControlFlag () {return force_att_control_flag_;}
+    /* latitude & longitude value for GPS based navigation */
+    inline void setCurrGpsPoint(const geographic_msgs::GeoPoint point) {curr_wgs84_poiont_ = point;}
+    inline const geographic_msgs::GeoPoint& getCurrGpsPoint() const {return curr_wgs84_poiont_;}
+
 
     const SensorFuser& getFuser(int mode)
     {
@@ -482,6 +488,9 @@ namespace aerial_robot_estimation
     bool un_descend_flag_;
     float landing_height_;
     bool force_att_control_flag_;
+
+    /* latitude & longitude point */
+    geographic_msgs::GeoPoint curr_wgs84_poiont_;
 
     void statePublish();
     void rosParamInit();

--- a/aerial_robot_kinetic.rosinstall
+++ b/aerial_robot_kinetic.rosinstall
@@ -16,6 +16,12 @@
     uri: https://github.com/JSKAerialRobot/sensor_interface.git
     version: da9c42f
 
+# RTK-GPS (forked)
+- git:
+    local-name: ublox_gps
+    uri: https://github.com/tongtybj/ublox.git
+    version: holybro_rtk_m8p
+
 # realsense
 - git:
     local-name: realsense-ros

--- a/aerial_robot_melodic.rosinstall
+++ b/aerial_robot_melodic.rosinstall
@@ -16,6 +16,12 @@
     uri: https://github.com/JSKAerialRobot/sensor_interface.git
     version: da9c42f
 
+# RTK-GPS (forked)
+- git:
+    local-name: ublox_gps
+    uri: https://github.com/tongtybj/ublox.git
+    version: holybro_rtk_m8p
+
 # realsense
 #- git:
 #    local-name: realsense-ros

--- a/robots/hydrus/launch/bringup.launch
+++ b/robots/hydrus/launch/bringup.launch
@@ -48,7 +48,7 @@
 
     ###########  Sensor Fusion  ###########
     <rosparam file="$(arg config_dir)/$(arg onboards_model)/StateEstimation.yaml" command="load" />
-    <rosparam file="$(arg config_dir)/Simulation.yaml" command="load" if="$(arg simulation)"/>
+    <rosparam file="$(arg config_dir)/Simulation.yaml" command="load" if="$(eval arg('simulation') and not arg('real_machine'))"/>
 
     ###########  Navigation  ###########
     <rosparam file="$(arg config_dir)/NavigationConfig.yaml" command="load" />
@@ -71,7 +71,7 @@
     <arg name="robot_ns" value="$(arg robot_ns)" />
     <arg name="rviz_config" value="$(find hydrus)/config/rviz_config" />
     <arg name="rviz_init_pose" value="$(arg config_dir)/RvizInit.yaml" />
-    <arg name="need_joint_state" value="false" if ="$(eval arg('simulation') + arg('real_machine') > 0)"/>
+    <arg name="need_joint_state" value="false" if ="$(eval arg('simulation') or arg('real_machine'))"/>
   </include>
 
   ###########  Sensors ###########
@@ -85,7 +85,7 @@
   <node pkg="aerial_robot_model" type="servo_bridge_node" name="servo_bridge" ns="$(arg robot_ns)" output="screen" />
 
   ########## Simulation in Gazebo #########
-  <include file="$(find aerial_robot_simulation)/launch/simulation.launch" if = "$(eval arg('simulation') * (1 - arg('real_machine')))" >
+  <include file="$(find aerial_robot_simulation)/launch/simulation.launch" if = "$(eval arg('simulation') and not arg('real_machine'))" >
     <arg name="robot_ns" default="$(arg robot_ns)" />
     <arg name="gui" default="false" if="$(arg headless)" />
     <arg name="headless" default="$(arg headless)" />


### PR DESCRIPTION
Implement process to use RTK GPS in sensor fusion.

- Usage of RTK GPS can be found: 
https://github.com/tongtybj/aerial_robot_demo/blob/9fb5aa894b0b3788b931754db43fc3427bdf6d15/mbzirc2020/mbzirc2020_task1/mbzirc2020_task1_common/launch/bringup.launch#L48-L51
https://github.com/tongtybj/aerial_robot_demo/blob/9fb5aa894b0b3788b931754db43fc3427bdf6d15/mbzirc2020/mbzirc2020_common/launch/base_sensors.launch#L47

- Following hard-coding only allows RTK GPS registered as the second GPS module. This means there must be a normal GPS as the primal module:
https://github.com/tongtybj/aerial_robot/blob/6bd01bd1db7f46c643b47b09145492d2764890d4/aerial_robot_base/config/sensors/gps/ublox_rtk_m8p.yaml#L5

- Add rosparameter file for UBlox NEO M9N  module. We need to discuss about the sensor temporal delay. Current optimal delay is -0.35 sec:
https://github.com/tongtybj/aerial_robot/blob/6bd01bd1db7f46c643b47b09145492d2764890d4/aerial_robot_base/config/sensors/gps/ublox_m9n.yaml#L10
  
