### PR TITLE
[WIP] add action server for joint trajectory following 

### DIFF
--- a/aerial_robot_model/include/aerial_robot_model/servo_bridge.h
+++ b/aerial_robot_model/include/aerial_robot_model/servo_bridge.h
@@ -58,8 +58,13 @@
 #include <kalman_filter/lpf_filter.h>
 
 /* util */
+#include <numeric>
 #include <string>
 #include <boost/algorithm/clamp.hpp>
+
+/* action server */
+#include <actionlib/server/simple_action_server.h>
+#include <control_msgs/FollowJointTrajectoryAction.h>
 
 using namespace std;
 
@@ -209,9 +214,13 @@ protected:
   bool simulation_mode_;
   int send_init_joint_pose_cnt_;
 
+  std::shared_ptr<actionlib::SimpleActionServer<control_msgs::FollowJointTrajectoryAction>> as_; 
+
   void servoStatesCallback(const spinal::ServoStatesConstPtr& state_msg, const std::string& servo_group_name);
   void servoCtrlCallback(const sensor_msgs::JointStateConstPtr& joints_ctrl_msg, const std::string& servo_group_name);
   bool servoTorqueCtrlCallback(std_srvs::SetBool::Request &req, std_srvs::SetBool::Response &res, const std::string& servo_group_name);
+
+  void followJointTrajectoryCallback(const control_msgs::FollowJointTrajectoryGoalConstPtr &goal);
 
 public:
   ServoBridge(ros::NodeHandle nh, ros::NodeHandle nhp);

--- a/robots/hydrus/scripts/follow_joint_trajectory_test.py
+++ b/robots/hydrus/scripts/follow_joint_trajectory_test.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+
+import copy
+import sys
+import time
+import rospy
+import math
+from control_msgs.msg import FollowJointTrajectoryActionGoal
+from trajectory_msgs.msg import JointTrajectoryPoint
+
+if __name__ == "__main__":
+
+    rospy.init_node("follow_joint_trajectory_test")
+
+    link_num = rospy.get_param("~link_num", 4)
+    duration = rospy.get_param("~duration", 8)
+    traj_points = rospy.get_param("~traj_points", 3)
+
+    pub = rospy.Publisher("follow_joint_trajectory/goal", FollowJointTrajectoryActionGoal, queue_size=1)
+
+    time.sleep(1)
+
+    msg = FollowJointTrajectoryActionGoal()
+    msg.header.stamp = rospy.Time.now()
+
+    msg.goal.trajectory.header.stamp = rospy.Time(0.0)
+    msg.goal.trajectory.joint_names = ['joint1', 'joint2', 'joint3']
+    init_point = JointTrajectoryPoint()
+    init_point.positions = [2 * math.pi / link_num] * (link_num - 1)
+    init_point.time_from_start = rospy.Duration(0.0)
+    msg.goal.trajectory.points.append(init_point)
+
+    for i in range(traj_points):
+        point = JointTrajectoryPoint()
+        point.positions = copy.copy(msg.goal.trajectory.points[-1].positions)
+        point.positions[i % (link_num-1)] =  -point.positions[i % (link_num-1)]
+        point.time_from_start = msg.goal.trajectory.points[-1].time_from_start  + rospy.Duration(duration)
+        msg.goal.trajectory.points.append(point)
+
+    pub.publish(msg)


### PR DESCRIPTION
Implement simple action server to support FollowJointTrajectory action in both simulation and real robot.

### TODO

- [ ] joint velocity is not support in both simulation and real robot. The simulation can be solved by using correct joint controller. For real robot, we need to improve the API usage about dynamixel motor in lower layer (i.e., Spinal, Neuron)
- [ ] feedback message is incomplete for simulation mode. The actual joint angles are not received by servo_bridge.