### PR TITLE
Support different series of force sensor for motor thrust test

### DIFF
--- a/aerial_robot_kinetic.rosinstall
+++ b/aerial_robot_kinetic.rosinstall
@@ -14,7 +14,7 @@
 - git:
     local-name: sensor_interface
     uri: https://github.com/JSKAerialRobot/sensor_interface.git
-    version: da9c42f
+    version: ec854cc
 
 # RTK-GPS (forked)
 - git:

--- a/aerial_robot_melodic.rosinstall
+++ b/aerial_robot_melodic.rosinstall
@@ -14,7 +14,7 @@
 - git:
     local-name: sensor_interface
     uri: https://github.com/JSKAerialRobot/sensor_interface.git
-    version: da9c42f
+    version: ec854cc
 
 # RTK-GPS (forked)
 - git:

--- a/aerial_robot_nerve/motor_test/README.md
+++ b/aerial_robot_nerve/motor_test/README.md
@@ -22,6 +22,7 @@ PC - spinal - ESC - rotor
    - `pwm_incremental_value`: the increamental value between two steps.
    - `min_pwm_value`/`max_pwm_value`: the min/max of the pwm value
    - `raise_duration`/`brake_duration`: these are the special parameters for one-shot mode, since we have to consider the raise-up phase after staring rotation and brake-down phase after stopping rotation. For small propellers (e.g. 5inch), these value can be small. For large propellers (e.g. 14inch), please increase there values
+   - `force_sensor`: the type of force sensor. Options are CFS034CA301U (default); PFS055YA501U6 (larger type)
 
    **sample**:
    - for 5inch propeller:

--- a/aerial_robot_nerve/motor_test/launch/test.launch
+++ b/aerial_robot_nerve/motor_test/launch/test.launch
@@ -9,10 +9,13 @@
   <!-- parameters for oneshot -->
   <arg name="raise_duration" default="2.0" />
   <arg name="brake_duration" default="4.0" />
+  <arg name="force_sensor" default="CFS034CA301U" /> <!-- other sensor: PFS055YA501U6 -->
 
   <node name="power_node"  pkg="takasako_sps" type="scpi_tcp_client_node" output="screen" />
 
-  <node name="forces_node" pkg="cfs_sensor" type="cfs_node"  output="screen"/>
+  <node name="forces_node" pkg="cfs_sensor" type="cfs_node"  output="screen" >
+    <rosparam file="$(find cfs_sensor)/config/$(arg force_sensor).yaml" command="load" />
+  </node>
 
   <include file="$(find spinal_ros_bridge)/launch/serial.launch" >
     <arg name="baud" value="921600" />


### PR DESCRIPTION
So far, we only support single type of force-torque sensor 

### TODO:
- [x] please first merge https://github.com/JSKAerialRobot/sensor_interface/pull/12
- [x] please update .rosinstall to use latest sensor_interface